### PR TITLE
Displaying a confirmation window only if there are dirty fields; fix

### DIFF
--- a/elu_slick.js
+++ b/elu_slick.js
@@ -147,9 +147,16 @@
 
         }
 
-        let confirm_unload = (on = true) => {
+        let confirm_unload = {
 
-          if (on) {
+          off: () => {
+
+            $(window).off('beforeunload')
+
+          },
+
+          on: () => {
+
             let inputsChanged = false
             $('input, select, textarea', $view).on('change', () => {
               inputsChanged = true
@@ -162,8 +169,7 @@
                 return ''
               }
             })
-          } else {
-            $(window).off('beforeunload')
+
           }
 
         }
@@ -172,7 +178,7 @@
         
             off: () => {
 
-                if (is_confirm_unload) confirm_unload()
+                if (is_confirm_unload) confirm_unload.on()
 
                 $('button', $view).each (function () {
                     if (is_visible (this.name, 0)) $(this).show (); else $(this).hide ()
@@ -188,7 +194,7 @@
             
             on: () => {
 
-                if (is_confirm_unload) confirm_unload(false)
+                if (is_confirm_unload) confirm_unload.off()
 
                 $('button', $view).each (function () {
                     if (is_visible (this.name, 1)) $(this).show (); else $(this).hide ()

--- a/elu_slick.js
+++ b/elu_slick.js
@@ -151,13 +151,7 @@
 
           if (on) {
             let inputsChanged = false
-            $('input', $view).on('change', () => {
-              inputsChanged = true
-            })
-            $('select', $view).on('change', () => {
-              inputsChanged = true
-            })
-            $('textarea', $view).on('change', () => {
+            $('input, select, textarea', $view).on('change', () => {
               inputsChanged = true
             })
 

--- a/elu_slick.js
+++ b/elu_slick.js
@@ -150,13 +150,26 @@
         let confirm_unload = (on = true) => {
 
           if (on) {
+            let inputsChanged = false
+            $('input', $view).on('change', () => {
+              inputsChanged = true
+            })
+            $('select', $view).on('change', () => {
+              inputsChanged = true
+            })
+            $('textarea', $view).on('change', () => {
+              inputsChanged = true
+            })
+
             $(window).bind("beforeunload", function(e) {
-              e.preventDefault();
-              e.returnValue = '';
-              return '';
-            });
+              if (inputsChanged) {
+                e.preventDefault()
+                e.returnValue = ''
+                return ''
+              }
+            })
           } else {
-            $(window).off('beforeunload');
+            $(window).off('beforeunload')
           }
 
         }


### PR DESCRIPTION
Displaying a confirmation window only if there are dirty fields (input, select or textarea); fixed issue with duplicate confirmation on updating data tasks/b7984570-ae57-2699-840f-a04238cc2e98